### PR TITLE
Add Anthropic Web Search tool

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -328,7 +328,23 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
       let tools: AnthropicTool[] = [];
       if (params.tools) {
         params.tools.forEach((tool) => {
-          if (tool.function) {
+          if (tool.type === 'web_search_20250305') {
+            tools.push({
+              type: tool.type,
+              name: tool.name ?? 'web_search',
+              ...(tool.max_uses !== undefined && { max_uses: tool.max_uses }),
+              ...(tool.allowed_domains && {
+                allowed_domains: tool.allowed_domains,
+              }),
+              ...(tool.blocked_domains && {
+                blocked_domains: tool.blocked_domains,
+              }),
+              ...(tool.user_location && { user_location: tool.user_location }),
+              ...(tool.cache_control && {
+                cache_control: { type: 'ephemeral' },
+              }),
+            } as any);
+          } else if (tool.function) {
             tools.push({
               name: tool.function.name,
               description: tool.function?.description || '',

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -314,9 +314,9 @@ export const BedrockConverseChatCompleteConfig: ProviderConfig = {
       params.tools?.forEach((tool) => {
         tools.push({
           toolSpec: {
-            name: tool.function.name,
-            description: tool.function.description,
-            inputSchema: { json: tool.function.parameters },
+            name: tool.function!.name,
+            description: tool.function!.description,
+            inputSchema: { json: tool.function!.parameters },
           },
         });
         if (tool.cache_control && !canBeAmazonModel) {

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -54,7 +54,7 @@ export const buildGoogleSearchRetrievalTool = (tool: Tool) => {
   const googleSearchRetrievalTool: GoogleSearchRetrievalTool = {
     googleSearchRetrieval: {},
   };
-  if (tool.function.parameters?.dynamicRetrievalConfig) {
+  if (tool.function?.parameters?.dynamicRetrievalConfig) {
     googleSearchRetrievalTool.googleSearchRetrieval.dynamicRetrievalConfig =
       tool.function.parameters.dynamicRetrievalConfig;
   }
@@ -290,16 +290,16 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
           recursivelyDeleteUnsupportedParameters(tool.function?.parameters);
           delete tool.function?.strict;
 
-          if (['googleSearch', 'google_search'].includes(tool.function.name)) {
+          if (['googleSearch', 'google_search'].includes(tool.function!.name)) {
             tools.push({ googleSearch: {} });
           } else if (
             ['googleSearchRetrieval', 'google_search_retrieval'].includes(
-              tool.function.name
+              tool.function!.name
             )
           ) {
             tools.push(buildGoogleSearchRetrievalTool(tool));
           } else {
-            functionDeclarations.push(tool.function);
+            functionDeclarations.push(tool.function!);
           }
         }
       });

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -367,16 +367,16 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
           recursivelyDeleteUnsupportedParameters(tool.function?.parameters);
           delete tool.function?.strict;
 
-          if (['googleSearch', 'google_search'].includes(tool.function.name)) {
+          if (['googleSearch', 'google_search'].includes(tool.function!.name)) {
             tools.push({ googleSearch: {} });
           } else if (
             ['googleSearchRetrieval', 'google_search_retrieval'].includes(
-              tool.function.name
+              tool.function!.name
             )
           ) {
             tools.push(buildGoogleSearchRetrievalTool(tool));
           } else {
-            functionDeclarations.push(tool.function);
+            functionDeclarations.push(tool.function!);
           }
         }
       });

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -355,8 +355,18 @@ export type ToolChoice = ToolChoiceObject | 'none' | 'auto' | 'required';
 export interface Tool extends PromptCache {
   /** The name of the function. */
   type: string;
-  /** A description of the function. */
-  function: Function;
+  /** A function tool definition when type is `function`. */
+  function?: Function;
+  /** The name of the tool when using non-function tools. */
+  name?: string;
+  /** Maximum number of times the tool can be used. */
+  max_uses?: number;
+  /** Allowed domains for web search tool. */
+  allowed_domains?: string[];
+  /** Blocked domains for web search tool. */
+  blocked_domains?: string[];
+  /** User location information for web search tool. */
+  user_location?: Record<string, any>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- support openai-compliant `web_search_20250305` tools
- update type definitions for tool metadata
- fix strict TypeScript checks in some providers

## Testing
- `npm run build`
- `npm run test:gateway` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_684043cd615c83338d5df3dc5eb2ba35